### PR TITLE
docs: add project readme and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Kleinanzeigen contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# kleinanzeigen
+# Kleinanzeigen
+
+Kleinanzeigen ist eine schlanke PHP-Anwendung zum Erstellen und Verwalten von Kleinanzeigen. Sie unterstützt das Generieren von PDF-Badges und das Hochladen von Bildern.
+
+## Installation
+
+1. Repository klonen:
+   ```bash
+   git clone <repository-url>
+   cd kleinanzeigen
+   ```
+2. Datenbankzugang in `config/database.php` anpassen und erforderliche Tabellen in einer MySQL-Datenbank anlegen.
+3. Optional: Beispiel-Daten importieren.
+4. Lokalen Entwicklungsserver starten:
+   ```bash
+   php -S localhost:8000
+   ```
+5. Im Browser `http://localhost:8000/index.php` öffnen.
+
+## Nutzung
+
+- Über **index.php** neue Artikel anlegen, Texte generieren und Bilder hochladen.
+- In **overview.php** bestehende Artikel einsehen und verwalten.
+- **configuration.php** bietet Einstellungen für Texte, PayPal und PDF-Badges.
+- Generierte PDF-Badges werden im Ordner `pdfs/` abgelegt, hochgeladene Bilder unter `uploads/`.
+
+## Lizenz
+
+Dieses Projekt steht unter der [MIT-Lizenz](LICENSE).


### PR DESCRIPTION
## Summary
- document project purpose, setup steps, and usage in README
- add MIT license file

## Testing
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_68a7265035c4832d8a8dd6f18e4bef21